### PR TITLE
Feat: Integrate icp-coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ npm install
 mops install
 ```
 
-### 3. Running Ollama
+### 3. AI Provider Setup
+
+This template supports two ways to utilize AI for processing prompts:
+
+#### 3a. Running Ollama (Local)
 
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.
 See the documentation on the [Ollama website](https://ollama.com/). Run:
@@ -83,6 +87,21 @@ ollama run llama3.1:8b
 ```
 
 Once the command executes and the model is loaded, you can terminate it by typing /bye. You won't need to do this step again.
+
+#### 3b. ICP-Coder
+
+Alternatively, you can use ICP-Coder, a Retrieval-Augmented Generation (RAG) pipeline for Motoko code search and code generation, providing enhanced context-aware responses with access to Motoko documentation and code examples. To enable this option:
+
+1. Clone the ICP-Coder repository and follow the setup instructions: https://github.com/DiegoFloresWenHao/ICP_Coder
+
+2. Set the `VITE_ICP_CODER_API_KEY` environment variable in your `.env` file:
+   ```bash
+   VITE_ICP_CODER_API_KEY=your_api_key_here
+   ```
+
+3. When the API key is configured, the frontend will display both Ollama and ICP-Coder options, allowing you to choose between providers.
+
+4. Without the API key, only the Ollama option will be available.
 
 ### 4. Deployment
 

--- a/src/frontend/src/config/llmConfig.ts
+++ b/src/frontend/src/config/llmConfig.ts
@@ -1,0 +1,144 @@
+/**
+ * LLM Configuration Management
+ * Handles configuration for different LLM providers
+ */
+
+export type LlmProvider = 'ollama' | 'api-server';
+
+export interface LlmConfig {
+  apiServerUrl: string;
+  apiKey: string | null;
+  timeouts: {
+    ollama: number;
+    apiServer: number;
+  };
+  retryConfig: {
+    maxRetries: number;
+    retryDelay: number;
+  };
+}
+
+class LlmConfigManager {
+  private static readonly CONFIG_STORAGE_KEY = 'llm-config';
+  private static readonly API_KEY_STORAGE_KEY = 'api-server-key';
+
+  private defaultConfig: LlmConfig = {
+    apiServerUrl: 'http://localhost:8000',
+    apiKey: null,
+    timeouts: {
+      ollama: 60000, // 60 seconds for Ollama
+      apiServer: 30000, // 30 seconds for API server
+    },
+    retryConfig: {
+      maxRetries: 3,
+      retryDelay: 1000, // 1 second
+    },
+  };
+
+  /**
+   * Gets the current LLM configuration
+   */
+  getConfig(): LlmConfig {
+    try {
+      const stored = localStorage.getItem(LlmConfigManager.CONFIG_STORAGE_KEY);
+      const apiKey = localStorage.getItem(LlmConfigManager.API_KEY_STORAGE_KEY);
+      
+      if (stored) {
+        const parsedConfig = JSON.parse(stored);
+        return {
+          ...this.defaultConfig,
+          ...parsedConfig,
+          apiKey,
+        };
+      }
+      
+      return {
+        ...this.defaultConfig,
+        apiKey,
+      };
+    } catch (error) {
+      console.warn('Failed to load LLM config from localStorage, using defaults:', error);
+      return this.defaultConfig;
+    }
+  }
+
+  /**
+   * Updates the LLM configuration
+   */
+  updateConfig(partialConfig: Partial<Omit<LlmConfig, 'apiKey'>>): void {
+    try {
+      const currentConfig = this.getConfig();
+      const updatedConfig = { ...currentConfig, ...partialConfig };
+      
+      // Don't store apiKey in the main config
+      const { apiKey, ...configToStore } = updatedConfig;
+      
+      localStorage.setItem(
+        LlmConfigManager.CONFIG_STORAGE_KEY,
+        JSON.stringify(configToStore)
+      );
+    } catch (error) {
+      console.error('Failed to save LLM config to localStorage:', error);
+    }
+  }
+
+  /**
+   * Sets the API key for the API server
+   */
+  setApiKey(apiKey: string): void {
+    try {
+      localStorage.setItem(LlmConfigManager.API_KEY_STORAGE_KEY, apiKey);
+    } catch (error) {
+      console.error('Failed to save API key to localStorage:', error);
+    }
+  }
+
+  /**
+   * Gets the API key for the API server
+   */
+  getApiKey(): string {
+    // Try environment variable first, then localStorage, then return empty string if not available
+    return import.meta.env.VITE_ICP_CODER_API_KEY || 
+           localStorage.getItem(LlmConfigManager.API_KEY_STORAGE_KEY) || 
+           '';
+  }
+
+  /**
+   * Checks if ICP-Coder is available (has API key)
+   */
+  isIcpCoderAvailable(): boolean {
+    return !!this.getApiKey();
+  }
+
+  /**
+   * Removes the API key from storage
+   */
+  clearApiKey(): void {
+    try {
+      localStorage.removeItem(LlmConfigManager.API_KEY_STORAGE_KEY);
+    } catch (error) {
+      console.error('Failed to clear API key from localStorage:', error);
+    }
+  }
+
+  /**
+   * Gets timeout for specific provider
+   */
+  getTimeout(provider: LlmProvider): number {
+    const config = this.getConfig();
+    return provider === 'ollama' ? config.timeouts.ollama : config.timeouts.apiServer;
+  }
+
+  /**
+   * Gets retry configuration
+   */
+  getRetryConfig() {
+    return this.getConfig().retryConfig;
+  }
+}
+
+// Export singleton instance
+export const llmConfigManager = new LlmConfigManager();
+
+// Export types and utilities
+export default llmConfigManager;

--- a/src/frontend/src/services/backendService.ts
+++ b/src/frontend/src/services/backendService.ts
@@ -1,4 +1,5 @@
 import { backend } from "../../../declarations/backend";
+import { llmConfigManager, type LlmProvider } from "../config/llmConfig";
 
 /**
  * Service for handling all backend canister API calls
@@ -30,11 +31,93 @@ export const backendService = {
   },
 
   /**
-   * Sends a prompt to the LLM backend
+   * Sends a prompt to the LLM backend (Ollama via Motoko)
    * @param prompt The user's prompt text
    * @returns Promise with the LLM response
    */
   async sendLlmPrompt(prompt: string): Promise<string> {
     return await backend.prompt(prompt);
+  },
+
+  /**
+   * Sends a prompt to the API server with context awareness
+   * @param prompt The user's prompt text
+   * @returns Promise with the LLM response from API server
+   */
+  async sendLlmPromptWithContext(prompt: string): Promise<string> {
+    const config = llmConfigManager.getConfig();
+    const apiKey = llmConfigManager.getApiKey();
+    const timeout = llmConfigManager.getTimeout('api-server');
+
+    // Check if ICP-Coder is available
+    if (!llmConfigManager.isIcpCoderAvailable()) {
+      throw new Error('ICP-Coder is not available - no API key configured');
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const response = await fetch(`${config.apiServerUrl}/v1/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+        },
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: prompt }],
+          model: 'gemini-2.5-flash'
+        }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error('Invalid API key. Please check your API server configuration.');
+        }
+        if (response.status === 404) {
+          throw new Error('API server endpoint not found. Please ensure the API server is running.');
+        }
+        throw new Error(`API Server error: ${response.status} - ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      
+      if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+        throw new Error('Invalid response format from API server');
+      }
+
+      return data.choices[0].message.content;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          throw new Error('Request timeout - API server is taking too long to respond');
+        }
+        if (error.message.includes('fetch')) {
+          throw new Error('Context service unavailable - check if API server is running');
+        }
+        throw error;
+      }
+      
+      throw new Error('Unknown error occurred while contacting API server');
+    }
+  },
+
+  /**
+   * Sends a prompt using the specified LLM provider
+   * @param prompt The user's prompt text
+   * @param provider The LLM provider to use
+   * @returns Promise with the LLM response
+   */
+  async sendPromptWithProvider(prompt: string, provider: LlmProvider): Promise<string> {
+    if (provider === 'api-server') {
+      return this.sendLlmPromptWithContext(prompt);
+    } else {
+      return this.sendLlmPrompt(prompt);
+    }
   },
 };

--- a/src/frontend/src/views/LlmPromptView.tsx
+++ b/src/frontend/src/views/LlmPromptView.tsx
@@ -1,6 +1,7 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useState, useMemo } from "react";
 import { Button, Card, TextArea } from "../components";
 import { backendService } from "../services/backendService";
+import { type LlmProvider } from "../config/llmConfig";
 
 interface LlmPromptViewProps {
   onError: (error: string) => void;
@@ -12,8 +13,18 @@ interface LlmPromptViewProps {
  */
 export function LlmPromptView({ onError, setLoading }: LlmPromptViewProps) {
   const [prompt, setPrompt] = useState<string>("");
-  const [llmResponse, setLlmResponse] = useState<string>("");
+  const [llmResponses, setLlmResponses] = useState<Record<LlmProvider, string>>({
+    ollama: "",
+    "api-server": ""
+  });
   const [llmLoading, setLlmLoading] = useState(false);
+  
+  // Check if ICP-Coder API key is available
+  const hasIcpCoderApiKey = useMemo(() => {
+    return !!import.meta.env.VITE_ICP_CODER_API_KEY;
+  }, []);
+  
+  const [llmProvider, setLlmProvider] = useState<LlmProvider>('ollama');
 
   const handleChangePrompt = (
     event: ChangeEvent<HTMLTextAreaElement>,
@@ -22,6 +33,14 @@ export function LlmPromptView({ onError, setLoading }: LlmPromptViewProps) {
       return;
     }
     setPrompt(event.target.value);
+    
+    // Clear all responses when prompt is cleared
+    if (event.target.value === "") {
+      setLlmResponses({
+        ollama: "",
+        "api-server": ""
+      });
+    }
   };
 
   const sendPrompt = async () => {
@@ -30,8 +49,11 @@ export function LlmPromptView({ onError, setLoading }: LlmPromptViewProps) {
     try {
       setLlmLoading(true);
       setLoading(true); // Use the setLoading prop to indicate loading state at App level
-      const res = await backendService.sendLlmPrompt(prompt);
-      setLlmResponse(res);
+      const res = await backendService.sendPromptWithProvider(prompt, llmProvider);
+      setLlmResponses(prev => ({
+        ...prev,
+        [llmProvider]: res
+      }));
     } catch (err) {
       console.error(err);
       onError(String(err));
@@ -41,20 +63,62 @@ export function LlmPromptView({ onError, setLoading }: LlmPromptViewProps) {
     }
   };
 
+  const getLoadingText = () => {
+    if (!llmLoading) return "Send Prompt";
+    return llmProvider === 'ollama' ? "Thinking..." : "Searching context...";
+  };
+
   return (
     <Card title="LLM Prompt">
+      {/* LLM Provider Selection - only show if there are multiple options */}
+      {hasIcpCoderApiKey && (
+        <div className="mb-4">
+          <div className="flex items-center gap-4">
+            <h4 className="text-sm font-medium text-gray-300">LLM Provider:</h4>
+            <label className="flex cursor-pointer items-center">
+              <input
+                type="radio"
+                name="llmProvider"
+                value="ollama"
+                checked={llmProvider === 'ollama'}
+                onChange={(e) => setLlmProvider(e.target.value as LlmProvider)}
+                className="mr-2 text-blue-400"
+              />
+              <span className="text-sm">
+                <span className="font-medium">Ollama</span> <span className="text-gray-400">(Fast)</span>
+              </span>
+            </label>
+            <label className="flex cursor-pointer items-center">
+              <input
+                type="radio"
+                name="llmProvider"
+                value="api-server"
+                checked={llmProvider === 'api-server'}
+                onChange={(e) => setLlmProvider(e.target.value as LlmProvider)}
+                className="mr-2 text-blue-400"
+              />
+              <span className="text-sm">
+                <span className="font-medium">ICP-Coder</span>
+              </span>
+            </label>
+          </div>
+        </div>
+      )}
+
       <TextArea
         value={prompt}
         onChange={handleChangePrompt}
         placeholder="Ask the LLM something..."
       />
       <Button onClick={sendPrompt} disabled={llmLoading}>
-        {llmLoading ? "Thinking..." : "Send Prompt"}
+        {getLoadingText()}
       </Button>
-      {!!llmResponse && (
+      {!!llmResponses[llmProvider] && (
         <div className={`mt-6 rounded bg-gray-800 p-4 text-left`}>
-          <h4 className="mt-0 text-blue-400">Response:</h4>
-          <p className="mb-0 whitespace-pre-wrap">{llmResponse}</p>
+          <h4 className="mt-0 text-blue-400">
+            Response {hasIcpCoderApiKey && llmProvider === 'api-server' ? '(ICP-Coder)' : '(Ollama)'}:
+          </h4>
+          <p className="mb-0 whitespace-pre-wrap">{llmResponses[llmProvider]}</p>
         </div>
       )}
     </Card>


### PR DESCRIPTION
**Integrate ICP-Coder with Vibe Coding Template**

This PR integrates **ICP-Coder**, an AI coding assistant for Internet Computer development. With this change, the template now supports two modes of AI-powered prompt processing:

- Ollama (local) : Existing support for running models locally.
- ICP-Coder (local): New integration that allows Motoko and Rust canister development assistance via MCP.

Why this matters:

- Expands template usability by providing another AI backend.
- Gives developers flexibility to choose between Ollama or ICP-Coder.

